### PR TITLE
Add vec/keyset/dict API

### DIFF
--- a/src/HackBuilder.php
+++ b/src/HackBuilder.php
@@ -10,7 +10,15 @@
 
 namespace Facebook\HackCodegen;
 
+
 use namespace HH\Lib\{C, Vec};
+
+enum ContainerType: string {
+  PHP_ARRAY = 'array';
+  DICT = 'dict';
+  VEC = 'vec';
+  KEYSET = 'keyset';
+}
 
 /**
  * Class to facilitate building code. It has methods for some common patterns
@@ -180,8 +188,22 @@ final class HackBuilder extends BaseCodeBuilder {
     return $this->addLine(' {')->indent();
   }
 
-  public function openBracket(): this {
-    return $this->addLine(' [')->indent();
+  public function openContainer(ContainerType $type): this {
+    switch ($type) {
+      case ContainerType::DICT:
+        $style = 'dict[';
+        break;
+      case ContainerType::KEYSET:
+        $style = 'keyset[';
+        break;
+      case ContainerType::PHP_ARRAY:
+        $style = 'array(';
+        break;
+      case ContainerType::VEC:
+        $style = 'vec[';
+        break;
+    }
+    return $this->addLine($style)->indent();
   }
 
   /**
@@ -191,7 +213,10 @@ final class HackBuilder extends BaseCodeBuilder {
     return $this->ensureNewLine()->unindent()->addLine('}');
   }
 
-  public function closeBracket(): this {
+  public function closeContainer(ContainerType $type): this {
+    if ($type === ContainerType::PHP_ARRAY) {
+      return $this->unindent()->add(')');
+    }
     return $this->unindent()->add(']');
   }
 

--- a/src/HackBuilder.php
+++ b/src/HackBuilder.php
@@ -18,6 +18,13 @@ enum ContainerType: string {
   DICT = 'dict';
   VEC = 'vec';
   KEYSET = 'keyset';
+  MAP = 'Map';
+  IMMU_MAP = 'ImmuMap';
+  VECTOR = 'Vector';
+  IMMU_VECTOR = 'ImmuVector';
+  SET = 'Set';
+  IMMU_SET = 'ImmuSet';
+  SHAPE_TYPE = 'shape';
 }
 
 /**
@@ -122,8 +129,7 @@ final class HackBuilder extends BaseCodeBuilder {
   ): this {
     $max_length = $max_length !== null
       ? $max_length
-      :
-        // subtract 3 for the two quotes and . operator
+      : // subtract 3 for the two quotes and . operator
         $this->getMaxCodeLength() - 3;
 
     $lines = $this->splitString($line, $max_length, /*preserve_space*/ true);
@@ -191,19 +197,24 @@ final class HackBuilder extends BaseCodeBuilder {
   public function openContainer(ContainerType $type): this {
     switch ($type) {
       case ContainerType::DICT:
-        $style = 'dict[';
-        break;
       case ContainerType::KEYSET:
-        $style = 'keyset[';
-        break;
-      case ContainerType::PHP_ARRAY:
-        $style = 'array(';
-        break;
       case ContainerType::VEC:
-        $style = 'vec[';
+        $container_sign = "[";
+        break;
+      case ContainerType::IMMU_MAP:
+      case ContainerType::IMMU_SET:
+      case ContainerType::IMMU_VECTOR:
+      case ContainerType::MAP:
+      case ContainerType::SET:
+      case ContainerType::VECTOR:
+        $container_sign = " {";
+        break;
+      case ContainerType::SHAPE_TYPE:
+      case ContainerType::PHP_ARRAY:
+        $container_sign = "(";
         break;
     }
-    return $this->addLine($style)->indent();
+    return $this->addLine(((string)$type).$container_sign)->indent();
   }
 
   /**
@@ -214,10 +225,26 @@ final class HackBuilder extends BaseCodeBuilder {
   }
 
   public function closeContainer(ContainerType $type): this {
-    if ($type === ContainerType::PHP_ARRAY) {
-      return $this->unindent()->add(')');
+    switch ($type) {
+      case ContainerType::DICT:
+      case ContainerType::KEYSET:
+      case ContainerType::VEC:
+        $container_sign = "]";
+        break;
+      case ContainerType::IMMU_MAP:
+      case ContainerType::IMMU_SET:
+      case ContainerType::IMMU_VECTOR:
+      case ContainerType::MAP:
+      case ContainerType::SET:
+      case ContainerType::VECTOR:
+        $container_sign = "}";
+        break;
+      case ContainerType::SHAPE_TYPE:
+      case ContainerType::PHP_ARRAY:
+        $container_sign = ")";
+        break;
     }
-    return $this->unindent()->add(']');
+    return $this->unindent()->add($container_sign);
   }
 
   public function closeStatement(): this {

--- a/src/HackBuilder.php
+++ b/src/HackBuilder.php
@@ -180,11 +180,19 @@ final class HackBuilder extends BaseCodeBuilder {
     return $this->addLine(' {')->indent();
   }
 
+  public function openBracket(): this {
+    return $this->addLine(' [')->indent();
+  }
+
   /**
    * Close a brace in a new line and sets one less level of indentation.
    */
   public function closeBrace(): this {
     return $this->ensureNewLine()->unindent()->addLine('}');
+  }
+
+  public function closeBracket(): this {
+    return $this->unindent()->add(']');
   }
 
   public function closeStatement(): this {

--- a/src/key-value-render/HackBuilderNativeKeyValueCollectionRenderer.php
+++ b/src/key-value-render/HackBuilderNativeKeyValueCollectionRenderer.php
@@ -18,7 +18,7 @@ class
     T as KeyedTraversable<Tk, Tv>,
   > implements IHackBuilderValueRenderer<T> {
   public function __construct(
-    private classname<T> $containerName,
+    private ContainerType $container,
     private IHackBuilderKeyRenderer<Tk> $keyRenderer,
     private IHackBuilderValueRenderer<Tv> $valueRenderer,
   ) {
@@ -28,9 +28,7 @@ class
     $key_renderer = $this->keyRenderer;
     $value_renderer = $this->valueRenderer;
 
-    $builder = (new HackBuilder($config))
-      ->add(strip_hh_prefix($this->containerName))
-      ->openBracket();
+    $builder = (new HackBuilder($config))->openContainer($this->container);
     foreach ($values as $key => $value) {
       $builder->addWithSuggestedLineBreaksf(
         "%s =>\t%s,\n",
@@ -38,6 +36,6 @@ class
         $value_renderer->render($config, $value),
       );
     }
-    return $builder->closeBracket()->getCode();
+    return $builder->closeContainer($this->container)->getCode();
   }
 }

--- a/src/key-value-render/HackBuilderNativeKeyValueCollectionRenderer.php
+++ b/src/key-value-render/HackBuilderNativeKeyValueCollectionRenderer.php
@@ -1,0 +1,43 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+namespace Facebook\HackCodegen;
+
+class
+  HackBuilderNativeKeyValueCollectionRenderer<
+    Tk as arraykey,
+    Tv,
+    T as KeyedTraversable<Tk, Tv>,
+  > implements IHackBuilderValueRenderer<T> {
+  public function __construct(
+    private classname<T> $containerName,
+    private IHackBuilderKeyRenderer<Tk> $keyRenderer,
+    private IHackBuilderValueRenderer<Tv> $valueRenderer,
+  ) {
+  }
+
+  final public function render(IHackCodegenConfig $config, T $values): string {
+    $key_renderer = $this->keyRenderer;
+    $value_renderer = $this->valueRenderer;
+
+    $builder = (new HackBuilder($config))
+      ->add(strip_hh_prefix($this->containerName))
+      ->openBracket();
+    foreach ($values as $key => $value) {
+      $builder->addWithSuggestedLineBreaksf(
+        "%s =>\t%s,\n",
+        $key_renderer->render($config, $key),
+        $value_renderer->render($config, $value),
+      );
+    }
+    return $builder->closeBracket()->getCode();
+  }
+}

--- a/src/key-value-render/HackBuilderNativeValueCollectionRenderer.php
+++ b/src/key-value-render/HackBuilderNativeValueCollectionRenderer.php
@@ -1,0 +1,32 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+namespace Facebook\HackCodegen;
+
+class HackBuilderNativeValueCollectionRenderer<Tv, T as Traversable<Tv>>
+  implements IHackBuilderValueRenderer<T> {
+  public function __construct(
+    private classname<T> $containerName,
+    private IHackBuilderValueRenderer<Tv> $valueRenderer,
+  ) {
+  }
+
+  final public function render(IHackCodegenConfig $config, T $values): string {
+    $value_renderer = $this->valueRenderer;
+    $builder = (new HackBuilder($config))
+      ->add(strip_hh_prefix($this->containerName))
+      ->openBracket();
+    foreach ($values as $value) {
+      $builder->addLinef('%s,', $value_renderer->render($config, $value));
+    }
+    return $builder->closeBracket()->getCode();
+  }
+}

--- a/src/key-value-render/HackBuilderNativeValueCollectionRenderer.php
+++ b/src/key-value-render/HackBuilderNativeValueCollectionRenderer.php
@@ -14,19 +14,17 @@ namespace Facebook\HackCodegen;
 class HackBuilderNativeValueCollectionRenderer<Tv, T as Traversable<Tv>>
   implements IHackBuilderValueRenderer<T> {
   public function __construct(
-    private classname<T> $containerName,
+    private ContainerType $container,
     private IHackBuilderValueRenderer<Tv> $valueRenderer,
   ) {
   }
 
   final public function render(IHackCodegenConfig $config, T $values): string {
     $value_renderer = $this->valueRenderer;
-    $builder = (new HackBuilder($config))
-      ->add(strip_hh_prefix($this->containerName))
-      ->openBracket();
+    $builder = (new HackBuilder($config))->openContainer($this->container);
     foreach ($values as $value) {
       $builder->addLinef('%s,', $value_renderer->render($config, $value));
     }
-    return $builder->closeBracket()->getCode();
+    return $builder->closeContainer($this->container)->getCode();
   }
 }

--- a/src/key-value-render/HackBuilderValues.php
+++ b/src/key-value-render/HackBuilderValues.php
@@ -26,14 +26,21 @@ abstract final class HackBuilderValues {
   public static function valueArray<Tv>(
     IHackBuilderValueRenderer<Tv> $vr,
   ): IHackBuilderValueRenderer<array<Tv>> {
-    return new HackBuilderValueArrayRenderer($vr);
+    return new HackBuilderNativeValueCollectionRenderer(
+      ContainerType::PHP_ARRAY,
+      $vr,
+    );
   }
 
   public static function keyValueArray<Tk as arraykey, Tv>(
     IHackBuilderKeyRenderer<Tk> $kr,
     IHackBuilderValueRenderer<Tv> $vr,
   ): IHackBuilderValueRenderer<array<Tk, Tv>> {
-    return new HackBuilderKeyValueArrayRenderer('array', $kr, $vr);
+    return new HackBuilderNativeKeyValueCollectionRenderer(
+      ContainerType::PHP_ARRAY,
+      $kr,
+      $vr,
+    );
   }
 
   public static function vector<Tv>(
@@ -51,7 +58,8 @@ abstract final class HackBuilderValues {
   public static function vec<Tv>(
     IHackBuilderValueRenderer<Tv> $vr,
   ): IHackBuilderValueRenderer<vec<Tv>> {
-    return new HackBuilderNativeValueCollectionRenderer(vec::class, $vr);
+    return
+      new HackBuilderNativeValueCollectionRenderer(ContainerType::VEC, $vr);
   }
 
   public static function set<Tv>(
@@ -69,7 +77,8 @@ abstract final class HackBuilderValues {
   public static function keyset<Tv as arraykey>(
     IHackBuilderValueRenderer<Tv> $vr,
   ): IHackBuilderValueRenderer<keyset<Tv>> {
-    return new HackBuilderNativeValueCollectionRenderer(keyset::class, $vr);
+    return
+      new HackBuilderNativeValueCollectionRenderer(ContainerType::KEYSET, $vr);
   }
 
   public static function map<Tk as arraykey, Tv>(
@@ -90,7 +99,11 @@ abstract final class HackBuilderValues {
     IHackBuilderKeyRenderer<Tk> $kr,
     IHackBuilderValueRenderer<Tv> $vr,
   ): IHackBuilderValueRenderer<dict<Tk, Tv>> {
-    return new HackBuilderNativeKeyValueCollectionRenderer(dict::class, $kr, $vr);
+    return new HackBuilderNativeKeyValueCollectionRenderer(
+      ContainerType::DICT,
+      $kr,
+      $vr,
+    );
   }
 
   public static function shapeWithUniformRendering<Tv>(

--- a/src/key-value-render/HackBuilderValues.php
+++ b/src/key-value-render/HackBuilderValues.php
@@ -48,6 +48,12 @@ abstract final class HackBuilderValues {
     return new HackBuilderValueCollectionRenderer(ImmVector::class, $vr);
   }
 
+  public static function vec<Tv>(
+    IHackBuilderValueRenderer<Tv> $vr,
+  ): IHackBuilderValueRenderer<vec<Tv>> {
+    return new HackBuilderNativeValueCollectionRenderer(vec::class, $vr);
+  }
+
   public static function set<Tv>(
     IHackBuilderValueRenderer<Tv> $vr,
   ): IHackBuilderValueRenderer<Set<Tv>> {
@@ -58,6 +64,12 @@ abstract final class HackBuilderValues {
     IHackBuilderValueRenderer<Tv> $vr,
   ): IHackBuilderValueRenderer<ImmSet<Tv>> {
     return new HackBuilderValueCollectionRenderer(ImmSet::class, $vr);
+  }
+
+  public static function keyset<Tv as arraykey>(
+    IHackBuilderValueRenderer<Tv> $vr,
+  ): IHackBuilderValueRenderer<keyset<Tv>> {
+    return new HackBuilderNativeValueCollectionRenderer(keyset::class, $vr);
   }
 
   public static function map<Tk as arraykey, Tv>(
@@ -72,6 +84,13 @@ abstract final class HackBuilderValues {
     IHackBuilderValueRenderer<Tv> $vr,
   ): IHackBuilderValueRenderer<ImmMap<Tk, Tv>> {
     return new HackBuilderKeyValueCollectionRenderer(ImmMap::class, $kr, $vr);
+  }
+
+  public static function dict<Tk as arraykey, Tv>(
+    IHackBuilderKeyRenderer<Tk> $kr,
+    IHackBuilderValueRenderer<Tv> $vr,
+  ): IHackBuilderValueRenderer<dict<Tk, Tv>> {
+    return new HackBuilderNativeKeyValueCollectionRenderer(dict::class, $kr, $vr);
   }
 
   public static function shapeWithUniformRendering<Tv>(

--- a/src/key-value-render/HackBuilderValues.php
+++ b/src/key-value-render/HackBuilderValues.php
@@ -46,13 +46,17 @@ abstract final class HackBuilderValues {
   public static function vector<Tv>(
     IHackBuilderValueRenderer<Tv> $vr,
   ): IHackBuilderValueRenderer<Vector<Tv>> {
-    return new HackBuilderValueCollectionRenderer(Vector::class, $vr);
+    return
+      new HackBuilderNativeValueCollectionRenderer(ContainerType::VECTOR, $vr);
   }
 
   public static function immVector<Tv>(
     IHackBuilderValueRenderer<Tv> $vr,
   ): IHackBuilderValueRenderer<ImmVector<Tv>> {
-    return new HackBuilderValueCollectionRenderer(ImmVector::class, $vr);
+    return new HackBuilderNativeValueCollectionRenderer(
+      ContainerType::IMMU_VECTOR,
+      $vr,
+    );
   }
 
   public static function vec<Tv>(
@@ -65,13 +69,17 @@ abstract final class HackBuilderValues {
   public static function set<Tv>(
     IHackBuilderValueRenderer<Tv> $vr,
   ): IHackBuilderValueRenderer<Set<Tv>> {
-    return new HackBuilderValueCollectionRenderer(Set::class, $vr);
+    return
+      new HackBuilderNativeValueCollectionRenderer(ContainerType::SET, $vr);
   }
 
   public static function immSet<Tv>(
     IHackBuilderValueRenderer<Tv> $vr,
   ): IHackBuilderValueRenderer<ImmSet<Tv>> {
-    return new HackBuilderValueCollectionRenderer(ImmSet::class, $vr);
+    return new HackBuilderNativeValueCollectionRenderer(
+      ContainerType::IMMU_SET,
+      $vr,
+    );
   }
 
   public static function keyset<Tv as arraykey>(
@@ -85,14 +93,22 @@ abstract final class HackBuilderValues {
     IHackBuilderKeyRenderer<Tk> $kr,
     IHackBuilderValueRenderer<Tv> $vr,
   ): IHackBuilderValueRenderer<Map<Tk, Tv>> {
-    return new HackBuilderKeyValueCollectionRenderer(Map::class, $kr, $vr);
+    return new HackBuilderNativeKeyValueCollectionRenderer(
+      ContainerType::MAP,
+      $kr,
+      $vr,
+    );
   }
 
   public static function immMap<Tk as arraykey, Tv>(
     IHackBuilderKeyRenderer<Tk> $kr,
     IHackBuilderValueRenderer<Tv> $vr,
   ): IHackBuilderValueRenderer<ImmMap<Tk, Tv>> {
-    return new HackBuilderKeyValueCollectionRenderer(ImmMap::class, $kr, $vr);
+    return new HackBuilderNativeKeyValueCollectionRenderer(
+      ContainerType::MAP,
+      $kr,
+      $vr,
+    );
   }
 
   public static function dict<Tk as arraykey, Tv>(
@@ -110,8 +126,8 @@ abstract final class HackBuilderValues {
     IHackBuilderValueRenderer<Tv> $vr,
   ): IHackBuilderValueRenderer<shape()> {
     /* HH_IGNORE_ERROR[4110] munging array to shape */
-    return new HackBuilderKeyValueArrayRenderer(
-      'shape',
+    return new HackBuilderNativeKeyValueCollectionRenderer(
+      ContainerType::SHAPE_TYPE,
       HackBuilderKeys::export(),
       $vr,
     );

--- a/test/HackBuilderTest.codegen
+++ b/test/HackBuilderTest.codegen
@@ -35,7 +35,7 @@ Map {
   \Facebook\HackCodegen\HackBuilderTest::class => \stdClass::class,
 }
 !@#$%codegentest:testDict
-$foo = dict [
+$foo = dict[
   'foo' => 1,
   'bar' => 2,
 ];
@@ -70,7 +70,7 @@ if ($value <= 0) {
 }
 
 !@#$%codegentest:testKeyset
-$foo = keyset [
+$foo = keyset[
   'foo',
   'bar',
 ];
@@ -163,7 +163,7 @@ try {
 }
 
 !@#$%codegentest:testVec
-$foo = vec [
+$foo = vec[
   'foo',
   'bar',
 ];

--- a/test/HackBuilderTest.codegen
+++ b/test/HackBuilderTest.codegen
@@ -34,6 +34,12 @@ if ($do_that) {
 Map {
   \Facebook\HackCodegen\HackBuilderTest::class => \stdClass::class,
 }
+!@#$%codegentest:testDict
+$foo = dict [
+  'foo' => 1,
+  'bar' => 2,
+];
+
 !@#$%codegentest:testDocBlock
 /**
  * Wow a really long comment that will span multiple lines and probably go over
@@ -62,6 +68,12 @@ if ($value <= 0) {
 } else {
   return 2;
 }
+
+!@#$%codegentest:testKeyset
+$foo = keyset [
+  'foo',
+  'bar',
+];
 
 !@#$%codegentest:testLambdaMap
 Map {
@@ -149,6 +161,12 @@ try {
 } finally {
   bump_ods();
 }
+
+!@#$%codegentest:testVec
+$foo = vec [
+  'foo',
+  'bar',
+];
 
 !@#$%codegentest:testVectorOfExportedVectors
 $foo = Vector {

--- a/test/HackBuilderTest.php
+++ b/test/HackBuilderTest.php
@@ -379,6 +379,46 @@ two line breaks. Also note that we include a newline and also '.
     $this->assertUnchanged($body->getCode());
   }
 
+  public function testVec(): void {
+    $body = $this
+      ->getHackBuilder()
+      ->addAssignment(
+        '$foo',
+        vec['foo', 'bar'],
+        HackBuilderValues::vec(
+          HackBuilderValues::export()
+        )
+      );
+    $this->assertUnchanged($body->getCode());
+  }
+
+  public function testKeyset(): void {
+    $body = $this
+      ->getHackBuilder()
+      ->addAssignment(
+        '$foo',
+        keyset['foo', 'bar'],
+        HackBuilderValues::keyset(
+          HackBuilderValues::export()
+        )
+      );
+    $this->assertUnchanged($body->getCode());
+  }
+
+  public function testDict(): void {
+    $body = $this
+      ->getHackBuilder()
+      ->addAssignment(
+        '$foo',
+        dict['foo' => 1, 'bar' => 2],
+        HackBuilderValues::dict(
+          HackBuilderKeys::export(),
+          HackBuilderValues::export(),
+        )
+      );
+    $this->assertUnchanged($body->getCode());
+  }
+
   public function testClassnameMap(): void {
     $body = $this
       ->getHackBuilder()


### PR DESCRIPTION
Summary: So far hack-codegen supported (Immu)Vector/(Immu)Set/(Immu)Map. Since the new HHVM version introduced vec/keyset/dict, we now add an option to support these collections in the framework.

Test Plan: Added new testcases for each vec/keyset/dict

Notes:
* CLA is submitted and should be acknowledged tomorrow
* We could probably refactor the collection renderers. It is a lot of duplicate code.