### PR TITLE
Document CodegenConstant, CodegenConstructor, CodegenEnum

### DIFF
--- a/src/CodegenConstant.php
+++ b/src/CodegenConstant.php
@@ -10,6 +10,11 @@
 
 namespace Facebook\HackCodegen;
 
+/**
+ * Generate code for a constant that is not part of a class.
+ *
+ * @see IHackCodegenFactory::codegenConstant
+ */
 final class CodegenConstant implements ICodeBuilderRenderer {
   use HackBuilderRenderer;
 
@@ -17,38 +22,51 @@ final class CodegenConstant implements ICodeBuilderRenderer {
   private ?string $type;
   private ?string $value = null;
 
+  /** @selfdocumenting */
   public function __construct(
     protected IHackCodegenConfig $config,
     private string $name,
   ) {
   }
 
+  /** @selfdocumenting */
   public function getName(): string {
     return $this->name;
   }
 
+  /** @selfdocumenting */
   public function getType(): ?string {
     return $this->type;
   }
 
+  /** @selfdocumenting */
   public function getValue(): mixed {
     return $this->value;
   }
 
+  /** @selfdocumenting */
   public function setDocBlock(string $comment): this {
     $this->comment = $comment;
     return $this;
   }
 
+  /** @selfdocumenting */
   public function setType(string $type): this {
     $this->type = $type;
     return $this;
   }
 
+  /** Set the type of the constant using a %-placeholder format string */
   public function setTypef(SprintfFormatString $format, mixed ...$args): this {
     return $this->setType(\vsprintf($format, $args));
   }
 
+  /**
+   * Set the value of the constant using a renderer.
+   *
+   * @param $renderer a renderer for the value. In general, this should be
+   *   created using `HackBuilderValues`
+   */
   public function setValue<T>(
       T $value,
       IHackBuilderValueRenderer<T> $renderer,

--- a/src/CodegenConstructor.php
+++ b/src/CodegenConstructor.php
@@ -11,13 +11,16 @@
 namespace Facebook\HackCodegen;
 
 /**
- * Generate code for a constructor. E.g.
+ * Generate code for a constructor.
  *
- * codegen_constructor()
+ * ```
+ * $codegen_factory->codegenConstructor()
  *  ->setBody('$this->x = new Foo();')
  *  ->render();
+ * ```
  */
 final class CodegenConstructor extends CodegenMethodish {
+  /** @selfdocumenting */
   public function __construct(IHackCodegenConfig $config) {
     parent::__construct($config, '__construct');
   }

--- a/src/CodegenEnum.php
+++ b/src/CodegenEnum.php
@@ -13,21 +13,25 @@ namespace Facebook\HackCodegen;
 use namespace HH\Lib\C;
 
 /**
- * Generate code for an enum. Please don't use this class directly; instead use
- * the function codegen_enum.  E.g.:
+ * Generate code for an enum.
  *
- * codegen_enum('Foo', 'int')
+ * ```
+ * $factory->codegenEnum('Foo', 'int')
  *  ->setIsAs('int')
  *  ->addConst('NAME', $value, 'Comment...')
  *  ->render();
- *
+ * ```
  */
 final class CodegenEnum extends CodegenClassish {
 
-  private ?string $declComment = null;
   private string $enumType;
   private ?string $isAs = null;
 
+  /** Create an instance.
+   *
+   * You should use `ICodegenFactory::codegenEnum` instead  of directly
+   * constructing.
+   */
   public function __construct(
     IHackCodegenConfig $config,
     string $name,
@@ -37,27 +41,26 @@ final class CodegenEnum extends CodegenClassish {
     $this->enumType = $enum_type;
   }
 
+  /** Make the enum usable directly as the specified type.
+   *
+   * For example, `->setIsAs('string')` will declare the enum as `as string`,
+   * allowing values to be directly passed into functions that take a `string`.
+   */
   public function setIsAs(string $is_as): this {
     invariant($this->isAs === null, 'isAs has already been set');
     $this->isAs = $is_as;
     return $this;
   }
 
+  /** @selfdocumenting */
   public function getIsAs(): ?string {
     return $this->isAs;
-  }
-
-  final public function setDeclComment(string $comment): this {
-    invariant($this->declComment === null, 'DeclComment has already been set');
-    $this->declComment = $comment."\n";
-    return $this;
   }
 
   <<__Override>>
   protected function buildDeclaration(HackBuilder $builder): void {
     $builder->addWithSuggestedLineBreaksf(
-      '%s%s%s%s',
-      (string)$this->declComment,
+      '%s%s%s',
       "enum ".$this->name,
       HackBuilder::DELIMITER.": ".$this->enumType,
       $this->isAs !== null ? HackBuilder::DELIMITER."as ".$this->isAs : '',


### PR DESCRIPTION
Remove `CodegenEnum::setDeclComment`: I /think/ it's been superceded by
`setDocBlock()` and there's no tests or examples.