### PR TITLE
Add methods for creating generics with constraints

### DIFF
--- a/src/CodegenClassish.php
+++ b/src/CodegenClassish.php
@@ -105,6 +105,40 @@ abstract class CodegenClassish implements ICodeBuilderRenderer {
     return $this;
   }
 
+  /** Add a generic parameter with subtype constraint.
+   *
+   * Subtype constraint of two types ```T``` and ```U``` will be evaluated to
+   * the following: ```T as U``` whereas this statement asserts
+   * that ```T``` must be a subtype of ```U```.
+   *
+   * @see addGeneric
+   * @see addGenericSupertypeConstraint
+   */
+  public function addGenericSubtypeConstraint(
+    string $subtype,
+    string $baseType
+  ): this {
+    $this->addGeneric($subtype.' as '.$baseType);
+    return $this;
+  }
+
+  /** Add a generic parameter with supertype constraint.
+   *
+   * Supertype constraint of two types ```T``` and ```U``` will be evaluated to
+   * the following: ```T super U``` whereas this statement asserts
+   * that ```T``` must be a supertype of ```U```.
+   *
+   * @see addGeneric
+   * @see addGenericSubtypeConstraint
+   */
+  public function addGenericSupertypeConstraint(
+    string $superType,
+    string $subtype
+  ): this {
+    $this->addGeneric($superType.' super '.$subtype);
+    return $this;
+  }
+
   /** @selfdocumenting */
   public function addMethods(Traversable<CodegenMethod> $methods): this {
     foreach ($methods as $method) {

--- a/test/CodegenClassTest.php
+++ b/test/CodegenClassTest.php
@@ -247,4 +247,31 @@ final class CodegenClassTest extends CodegenBaseTest {
     $code = $cgf->codegenClass('Foo')->setExtendsf('X<%s>', 'Y')->render();
     $this->assertContains('extends X<Y>', $code);
   }
+
+  public function testGenericsWithSubtypeConstraints(): void {
+    $cgf = $this->getCodegenFactory();
+    $code = $cgf->codegenClass('GenericsTestClass')->addGenericSubtypeConstraint('T', 'U')->render();
+    $this->assertContains('T as U', $code);
+  }
+
+  public function testGenericsWithSuperTypeConstraints(): void {
+    $cgf = $this->getCodegenFactory();
+    $code = $cgf->codegenClass('GenericsTestClass')->addGenericSupertypeConstraint('T', 'U')->render();
+    $this->assertContains('T super U', $code);
+  }
+
+  public function testGenericsWithConstraints(): void {
+    $cgf = $this->getCodegenFactory();
+    $code = $cgf
+      ->codegenClass('GenericsTestClass')
+      ->addGenericSubtypeConstraint('Tk', 'Tv')
+      ->addGenericSupertypeConstraint('Tu', 'Sp')
+      ->addGenericSubtypeConstraint('Tt', 'Xx')
+      ->addGeneric('Tsingle')
+      ->render();
+    $this->assertContains('Tk as Tv', $code);
+    $this->assertContains('Tu super Sp', $code);
+    $this->assertContains('Tt as Xx', $code);
+    $this->assertContains('Tsingle', $code);
+  }
 }

--- a/test/CodegenClassTest.php
+++ b/test/CodegenClassTest.php
@@ -245,18 +245,21 @@ final class CodegenClassTest extends CodegenBaseTest {
   public function testExtendsGeneric(): void {
     $cgf = $this->getCodegenFactory();
     $code = $cgf->codegenClass('Foo')->setExtendsf('X<%s>', 'Y')->render();
+
     $this->assertContains('extends X<Y>', $code);
   }
 
   public function testGenericsWithSubtypeConstraints(): void {
     $cgf = $this->getCodegenFactory();
     $code = $cgf->codegenClass('GenericsTestClass')->addGenericSubtypeConstraint('T', 'U')->render();
+
     $this->assertContains('T as U', $code);
   }
 
   public function testGenericsWithSuperTypeConstraints(): void {
     $cgf = $this->getCodegenFactory();
     $code = $cgf->codegenClass('GenericsTestClass')->addGenericSupertypeConstraint('T', 'U')->render();
+
     $this->assertContains('T super U', $code);
   }
 
@@ -269,6 +272,7 @@ final class CodegenClassTest extends CodegenBaseTest {
       ->addGenericSubtypeConstraint('Tt', 'Xx')
       ->addGeneric('Tsingle')
       ->render();
+
     $this->assertContains('Tk as Tv', $code);
     $this->assertContains('Tu super Sp', $code);
     $this->assertContains('Tt as Xx', $code);


### PR DESCRIPTION
Add methods for creating generics with **subtype** and **supertype** constraints. 

Ensure the correctness of the generated code by newly added methods by adding new tests.

Fix #86 

**UPD:** By the way, what is wrong with the build?