### PR TITLE
Support for rendering enums in CodegenFile

### DIFF
--- a/src/CodegenFile.hack
+++ b/src/CodegenFile.hack
@@ -45,6 +45,7 @@ final class CodegenFile {
   private vec<CodegenType> $beforeTypes = vec[];
   private vec<CodegenType> $afterTypes = vec[];
   private vec<CodegenConstant> $consts = vec[];
+  private vec<CodegenEnum> $enums = vec [];
   private bool $doClobber = false;
   protected ?CodegenGeneratedFrom $generatedFrom;
   private bool $isSignedFile = true;
@@ -82,6 +83,22 @@ final class CodegenFile {
   public function addOriginalFile(string $file_name): this {
     $this->otherFileNames[] = $file_name;
     return $this;
+  }
+
+  public function addEnums(Traversable<CodegenEnum> $enums): this {
+    foreach ($enums as $enum) {
+      $this->addEnum($enum);
+    }
+    return $this;
+  }
+
+  public function addEnum(CodegenEnum $enum): this {
+    $this->enums[] = $enum;
+    return $this;
+  }
+
+  public function getEnums(): vec<CodegenEnum> {
+    return $this->enums;
   }
 
   public function addClasses(Traversable<CodegenClassish> $classes): this {
@@ -411,6 +428,10 @@ final class CodegenFile {
     }
     foreach ($this->consts as $const) {
       $builder->ensureEmptyLine()->add($const->render());
+    }
+    foreach ($this->enums as $enum) {
+      $builder->ensureNewLine()->newLine();
+      $builder->add($enum->render());
     }
     foreach ($this->functions as $function) {
       $builder->ensureNewLine()->newLine();

--- a/tests/CodegenFileTest.codegen
+++ b/tests/CodegenFileTest.codegen
@@ -151,6 +151,21 @@ function my_func(
   );
 }
 
+!@#$%codegentest:testGenerateEnums
+<?hh // strict
+// Codegen Tests
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * @-generated SignedSource<<9627a8d7e6cf7a65a9bf2ad85d657e03>>
+ */
+
+
+enum TestEnum : int {
+  FIRST = 0;
+  SECOND = 1;
+}
+
 !@#$%codegentest:testGenerateTopLevelFunctions
 <?hh // strict
 // Codegen Tests

--- a/tests/CodegenFileTest.hack
+++ b/tests/CodegenFileTest.hack
@@ -42,6 +42,20 @@ final class CodegenFileTest extends CodegenBaseTest {
     expect_with_context(static::class, $code)->toBeUnchanged();
   }
 
+  public function testGenerateEnums(): void {
+    $cgf = $this->getCodegenFactory();
+    $enum = $cgf->codegenEnum('TestEnum', 'int')
+      ->addMember(
+        $cgf->codegenEnumMember('FIRST')
+          ->setValue(0, HackBuilderValues::export()))
+      ->addMember(
+        $cgf->codegenEnumMember('SECOND')
+          ->setValue(1, HackBuilderValues::export()));
+    $code = $cgf->codegenFile('no_file')->addEnum($enum)->render();
+
+    expect_with_context(static::class, $code)->toBeUnchanged();
+  }
+
   public function testPartiallyGenerated(): void {
     $cgf = $this->getCodegenFactory();
     $code = $cgf


### PR DESCRIPTION
Summary:
In commit cd388d6c24cbeb3a5b55e6226274e63dcc6ce189 to hhvm/hack-codegen,
CodegenEnum stopped extending CodegenClassish, which means that
CodegenFile::addClass can no longer be used to add an Enum into
CodegenFile.

This diff adds methods CodegenFile::addEnum[s]/getEnums identical to
addClass[es]/getClasses but that operate on CodegenEnum instances. When
the CodegenFile is rendered, enums will be rendered after constants and
before any functions or classes.

Test Plan:
Add a test case into tests/CodegenFileTest