### PR TITLE
Add type hints to lambda parameters

### DIFF
--- a/src/CodegenFile.hack
+++ b/src/CodegenFile.hack
@@ -400,7 +400,7 @@ final class CodegenFile {
       $this->fileNamespace ?? '',
     );
 
-    $get_use_statement = ($type, $ns, $as) ==>
+    $get_use_statement = (string $type, string $ns, ?string $as) ==>
       \sprintf('use %s %s%s;', $type, $ns, $as === null ? '' : ' as '.$as);
 
     foreach ($this->useNamespaces as $ns => $as) {

--- a/tests/HackBuilderTest.hack
+++ b/tests/HackBuilderTest.hack
@@ -9,6 +9,8 @@
 
 namespace Facebook\HackCodegen;
 
+use namespace HH\Lib\Regex;
+
 final class HackBuilderTest extends CodegenBaseTest {
 
   private function getHackBuilder(): HackBuilder {
@@ -78,7 +80,7 @@ final class HackBuilderTest extends CodegenBaseTest {
   }
 
   public function testRegex(): void {
-    $make_code = $re ==> $this->getHackBuilder()
+    $make_code = (Regex\Pattern<Regex\Match> $re) ==> $this->getHackBuilder()
       ->addValue($re, HackBuilderValues::regex())
       ->getCode();
     expect($make_code(re"/foo/"))->toBeSame('re"/foo/"');


### PR DESCRIPTION
Summary: required for .hhconfig disallow_ambiguous_lambda.
