### PR TITLE
Use `Str\join()`, instead of `implode()`

### DIFF
--- a/src/BaseCodeBuilder.hack
+++ b/src/BaseCodeBuilder.hack
@@ -331,7 +331,7 @@ abstract class BaseCodeBuilder {
         }
       }
     }
-    return $this->add(\implode("\n  ", $final_lines));
+    return $this->add(Str\join($final_lines, "\n  "));
   }
 
   /**

--- a/src/CodegenClass.hack
+++ b/src/CodegenClass.hack
@@ -125,7 +125,7 @@ final class CodegenClass extends CodegenClassish {
           $param_names[] = $match[0];
         }
       }
-      $params_str = \implode(', ', $param_names);
+      $params_str = Str\join( $param_names, ', ');
       $body = 'return new '.$this->getName().'('.$params_str.');';
 
       $this->wrapperFunc = (

--- a/src/CodegenClassish.hack
+++ b/src/CodegenClassish.hack
@@ -286,7 +286,7 @@ abstract class CodegenClassish implements ICodeBuilderRenderer {
         $$,
         $decl ==> '    '.$decl.",\n",
       )
-      |> \implode("", $$)
+      |> Str\join($$, '')
       |> Str\strip_suffix($$, ",\n")
       |> "\n  <\n".$$."\n  >";
   }
@@ -383,7 +383,7 @@ abstract class CodegenClassish implements ICodeBuilderRenderer {
     $doc_block_parts = \array_filter(varray[$this->docBlock, $generated_from]);
 
     if ($doc_block_parts) {
-      $builder->addDocBlock(\implode("\n\n", $doc_block_parts));
+      $builder->addDocBlock(Str\join($doc_block_parts, "\n\n"));
     }
 
     $wrapper_func = $this->wrapperFunc;

--- a/src/CodegenFile.hack
+++ b/src/CodegenFile.hack
@@ -485,7 +485,7 @@ final class CodegenFile {
         $all_content[] = $content;
       }
     }
-    return \implode('', $all_content);
+    return Str\join($all_content, '');
   }
 
   public function setGeneratedFrom(CodegenGeneratedFrom $from): this {

--- a/src/CodegenFunctionish.hack
+++ b/src/CodegenFunctionish.hack
@@ -150,7 +150,7 @@ abstract class CodegenFunctionish implements ICodeBuilderRenderer {
   ): string {
     $builder = (new HackBuilder($this->config))
       ->add($keywords)
-      ->addf('%s(%s)', $this->name, \implode(', ', $this->parameters))
+      ->addf('%s(%s)', $this->name, Str\join($this->parameters, ', '))
       ->addIf($this->returnType !== null, ': '.$this->returnType);
 
     $code = $builder->getCode();

--- a/src/CodegenWithAttributes.hack
+++ b/src/CodegenWithAttributes.hack
@@ -8,7 +8,7 @@
  */
 namespace Facebook\HackCodegen;
 
-use namespace HH\Lib\{C, Dict, Vec};
+use namespace HH\Lib\{C, Dict, Str, Vec};
 
 trait CodegenWithAttributes {
   protected IHackCodegenConfig $config;
@@ -49,17 +49,17 @@ trait CodegenWithAttributes {
     }
 
     return '<<'.
-      \implode(
-        ', ',
+      Str\join(
         Dict\map_with_key(
           $attributes,
           ($name, $params) ==> {
             if (C\is_empty($params)) {
               return $name;
             }
-            return $name.'('.\implode(', ', $params).')';
+            return $name.'('.Str\join($params, ', ').')';
           },
         ),
+        ', '
       ).
       '>>';
   }

--- a/src/HackBuilder.hack
+++ b/src/HackBuilder.hack
@@ -55,7 +55,7 @@ final class HackBuilder extends BaseCodeBuilder {
     $max_length = $this->getMaxCodeLength() - 4;
 
     // Let's put everything in a single line
-    $args = '('.\implode(', ', $params).')';
+    $args = '('.Str\join($params, ', ').')';
     $composite_line = $func_call_line.$args;
     // Ignore suggested line breaks within individual args; otherwise we could
     // split in the middle of arguments rather than after each parameter.

--- a/src/HackfmtFormatter.hack
+++ b/src/HackfmtFormatter.hack
@@ -46,7 +46,7 @@ final class HackfmtFormatter implements ICodegenFormatter {
       $exit_code === 0,
       'Failed to invoke hackfmt',
     );
-    return \implode("\n", $output)."\n";
+    return Str\join($output, "\n")."\n";
   }
 
   <<__Memoize>>

--- a/src/PartiallyGeneratedCode.hack
+++ b/src/PartiallyGeneratedCode.hack
@@ -9,7 +9,7 @@
 
 namespace Facebook\HackCodegen;
 
-use namespace HH\Lib\C;
+use namespace HH\Lib\{C, Str};
 
 /**
  * Manage partially generated code.  The main operation is to merge existing
@@ -79,7 +79,7 @@ final class PartiallyGeneratedCode {
             }
           }
           if ($content) {
-            $merged[] = \implode("\n\n", $content);
+            $merged[] = Str\join($content, "\n\n");
           } else {
             // This manual section is new, so insert inside it the chunk from
             // the generated code (e.g. the generated code can have a comment
@@ -89,7 +89,7 @@ final class PartiallyGeneratedCode {
         }
       }
     }
-    return \implode("\n", \array_filter($merged));
+    return Str\join(\array_filter($merged), "\n");
   }
 
   /**
@@ -117,7 +117,7 @@ final class PartiallyGeneratedCode {
         $generated[] = $chunk;
       }
     }
-    return \implode("\n", $generated);
+    return Str\join($generated, "\n");
   }
 
   /**
@@ -150,7 +150,7 @@ final class PartiallyGeneratedCode {
     $lines = \explode("\n", $code);
     foreach ($lines as $line) {
       if (\strpos($line, self::$manualEnd) !== false) {
-        yield tuple($current_id, \implode("\n", $chunk));
+        yield tuple($current_id, Str\join($chunk, "\n"));
         $chunk = varray[$line];
         $current_id = null;
 
@@ -167,7 +167,7 @@ final class PartiallyGeneratedCode {
         }
 
         $chunk[] = $line;
-        yield tuple(null, \implode("\n", $chunk));
+        yield tuple(null, Str\join($chunk, "\n"));
         $chunk = varray[];
         $current_id = \trim(\preg_replace($begin, '\\1', $line));
 
@@ -187,11 +187,10 @@ final class PartiallyGeneratedCode {
       );
     }
     if ($code !== '') {
-      yield tuple(null, \implode("\n", $chunk));
+      yield tuple(null, Str\join($chunk, "\n"));
     }
   }
 }
 
 final class PartiallyGeneratedCodeException extends \Exception {
 }
-;


### PR DESCRIPTION
HackBuilder::addMultilineCall passes $params `Traversable<string>`
to `implode()`. `Implode()` is untyped. Passing a `Generator<string>`
results in a warning and a return of a null.
`Str\join()` correctly checks for `Container<_>` before passing
the value on to `implode()`.