### PR TITLE
Fix lint in HackfmtFormatter.hack

### DIFF
--- a/src/HackfmtFormatter.hack
+++ b/src/HackfmtFormatter.hack
@@ -71,7 +71,7 @@ final class HackfmtFormatter implements ICodegenFormatter {
 
     return Vec\map(
       $options,
-      $option ==> \escapeshellarg($option),
+      \escapeshellarg<>,
     ) |> Str\join($$, ' ');
   }
 }


### PR DESCRIPTION
Our CI was failing with:
```
  + hhvm vendor/hhvm/hhast/bin/hhast-lint
  You have made a lambda which forwards all its arguments to a static method or function.
  The order of the parameters is the same as the order of the arguments.
  You could create a function reference instead. -> \escapeshellarg<>
    Linter: DontCreateForwardingLambdas
    Location: /home/runner/work/hack-codegen/hack-codegen/src/HackfmtFormatter.hack:74:6
    Code:
    >      $option ==> \escapeshellarg($option)
```
on HHVM latest. Apply the change suggested by the linter.