### PR TITLE
Add `.hack` extension to the temporary file

### DIFF
--- a/src/HackfmtFormatter.hack
+++ b/src/HackfmtFormatter.hack
@@ -27,7 +27,7 @@ final class HackfmtFormatter implements ICodegenFormatter {
     $tempnam = \tempnam(
       \sys_get_temp_dir(),
       'hack-codegen-hackfmt',
-    );
+    ) + ".hack";
 
     $options = $this->getFormattedOptions();
 


### PR DESCRIPTION
The extension is required in hackfmt from nightly HHVM, otherwise an error will occur like this:

https://github.com/hhvm/hhast/runs/6732641998?check_suite_focus=true