### PR TITLE
Add CodegenFunctionish::setContexts

### DIFF
--- a/src/CodegenFunctionish.hack
+++ b/src/CodegenFunctionish.hack
@@ -76,6 +76,22 @@ abstract class CodegenFunctionish implements ICodeBuilderRenderer {
     return $this;
   }
 
+  /** Set or remove the contexts.
+   *
+   * - if passed `null`, the function or method will not contain a contexts
+   *   declaration, e.g. `function foo(): void {}`; this is equivalent to
+   *   `function foo()[defaults]: void {}`
+   * - if passed the empty set (e.g. `keyset[]`), the function will have an
+   *   empty contexts declaration, e.g. `function foo()[]: void {}`. This is
+   *   considered to be an approximation of declaration pure functions.
+   */
+  public function setContexts(
+    ?Container<string> $contexts,
+  ): this {
+    $this->contexts = ($contexts is null) ? null : keyset($contexts);
+    return $this;
+  }
+
   public function setReturnType(string $type): this {
     return $this->setReturnTypef('%s', $type);
   }


### PR DESCRIPTION
This is needed in order to be able to codegen pure functions.

I've not added tests as there does not currently appear to be an environment where the test suite is runnable.